### PR TITLE
Create  CVE-2018-11759-Apache mod_jk access control bypass.bcheck

### DIFF
--- a/vulnerabilities-CVEd/CVE-2018-11759-Apache mod_jk access control bypass.bcheck
+++ b/vulnerabilities-CVEd/CVE-2018-11759-Apache mod_jk access control bypass.bcheck
@@ -1,0 +1,25 @@
+metadata:
+    language: v2-beta
+    name: "CVE-2018-11759 - Apache mod_jk access control bypass"
+    description: "Checks for CVE-2018-11759 -Apache mod_jk access control bypass"
+    author: "CDonkin"
+    tags: "CVE-2018-11759", "mod_jk"
+
+run for each:
+    potential_path =
+        "/jkstatus",
+        "/jkstatus;"
+
+given host then
+    send request called check:
+        method: "GET"
+        path: {potential_path}
+
+    if "JK Status Manager" in {check.response.body} then
+        report issue:
+            severity: High
+            confidence: certain
+            detail: `jkstatus found at {potential_path}.`
+            remediation: "Apply the relevant patches"
+    end if
+        

--- a/vulnerabilities-CVEd/CVE-2018-11759-Apache mod_jk access control bypass.bcheck
+++ b/vulnerabilities-CVEd/CVE-2018-11759-Apache mod_jk access control bypass.bcheck
@@ -17,7 +17,7 @@ given host then
 
     if "JK Status Manager" in {check.response.body} then
         report issue:
-            severity: High
+            severity: high
             confidence: certain
             detail: `jkstatus found at {potential_path}.`
             remediation: "Apply the relevant patches"


### PR DESCRIPTION
This is a bcheck to detect CVE-2018-11759. This PoC can be used to test the bcheck:

https://github.com/immunIT/CVE-2018-11759

### BCheck Contributions

* [ ] BCheck compiles and executes as expected
* [ ] BCheck contains appropriate metadata (name, version, author, description and appropriate tags)
* [ ] Only .bcheck files have been added or modified
* [ ] BCheck is in the appropriate folder
* [ ] PR contains single or limited number of BChecks (Multiple PRs are preferred)
* [ ] BCheck attempts to minimize false positives
